### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Test: @test
         good_exprs = [
             :(@hello),
             Meta.parse("@hello"),
-            Meta.parse("@hello()") # Is this correct?
+            Meta.parse("@hello()"), # Is this correct?
         ]
         bad_exprs = [
             Meta.parse("@foo bar"),
@@ -17,7 +17,7 @@ using Test: @test
             Meta.parse("foo()"),
             Meta.parse("foo(@bar)"),
             Meta.parse("@foo @bar"),
-            Meta.parse("@foo(@bar)")
+            Meta.parse("@foo(@bar)"),
         ]
         for expr in good_exprs
             @test SciMLPublic._is_valid_macro_expr(expr)
@@ -32,14 +32,14 @@ end
 
 module TestModule1
 
-using SciMLPublic: @public
+    using SciMLPublic: @public
 
-export f
-@public g
+    export f
+    @public g
 
-function f end
-function g end
-function h end
+    function f end
+    function g end
+    function h end
 
 end # module TestModule1
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)