### PR TITLE
Canonicalize tests to @safetestset for isolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["The Julia Project", "contributors"]
 version = "1.0.1"
 
 [compat]
+SafeTestsets = "0.1, 1"
 Test = "1.10"
 julia = "1.10"
 
@@ -11,6 +12,7 @@ julia = "1.10"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 
 [targets]
-test = ["Test", "Aqua", "JET"]
+test = ["Test", "Aqua", "JET", "SafeTestsets"]

--- a/test/get_symbols_tests.jl
+++ b/test/get_symbols_tests.jl
@@ -1,0 +1,9 @@
+using SciMLPublic
+using Test
+
+@testset "_get_symbols" begin
+    @test SciMLPublic._get_symbols(:foo) == [:foo]
+    @test SciMLPublic._get_symbols(:((a, b, c))) == [:a, :b, :c]
+    @test SciMLPublic._get_symbols(:(@hello)) == [Symbol("@hello")]
+    @test SciMLPublic._get_symbols(:((foo, bar, @hello))) == [:foo, :bar, Symbol("@hello")]
+end

--- a/test/macro_expr_tests.jl
+++ b/test/macro_expr_tests.jl
@@ -1,0 +1,24 @@
+using SciMLPublic
+using Test
+
+@testset "_is_valid_macro_expr" begin
+    good_exprs = [
+        :(@hello),
+        Meta.parse("@hello"),
+        Meta.parse("@hello()"), # Is this correct?
+    ]
+    bad_exprs = [
+        Meta.parse("@foo bar"),
+        Meta.parse("@foo(bar)"),
+        Meta.parse("foo()"),
+        Meta.parse("foo(@bar)"),
+        Meta.parse("@foo @bar"),
+        Meta.parse("@foo(@bar)"),
+    ]
+    for expr in good_exprs
+        @test SciMLPublic._is_valid_macro_expr(expr)
+    end
+    for expr in bad_exprs
+        @test !SciMLPublic._is_valid_macro_expr(expr)
+    end
+end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -10,5 +11,6 @@ SciMLPublic = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,15 +1,18 @@
-using SciMLPublic
-using Aqua
-using JET
-using Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using SciMLPublic
+    using Aqua
+    using Test
     # deps_compat(extras) currently fails; run the rest and mark it broken.
     # Tracked in https://github.com/SciML/SciMLPublic.jl/issues/34
     Aqua.test_all(SciMLPublic; deps_compat = false)
     @test_broken false  # Aqua deps_compat: no [compat] for Aqua/JET extras — tracked in https://github.com/SciML/SciMLPublic.jl/issues/34
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using SciMLPublic
+    using JET
+    using Test
     JET.test_package(SciMLPublic; target_defined_modules = true)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,20 +2,7 @@ import SciMLPublic
 import Test
 
 using Test: @testset
-using Test: @test
-
-module TestModule1
-
-    using SciMLPublic: @public
-
-    export f
-    @public g
-
-    function f end
-    function g end
-    function h end
-
-end # module TestModule1
+using SafeTestsets: @safetestset
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -23,69 +10,20 @@ if GROUP == "QA"
     include(joinpath(@__DIR__, "qa", "qa.jl"))
 else
     @testset "SciMLPublic.jl package" begin
-        @testset "_is_valid_macro_expr" begin
-            good_exprs = [
-                :(@hello),
-                Meta.parse("@hello"),
-                Meta.parse("@hello()"), # Is this correct?
-            ]
-            bad_exprs = [
-                Meta.parse("@foo bar"),
-                Meta.parse("@foo(bar)"),
-                Meta.parse("foo()"),
-                Meta.parse("foo(@bar)"),
-                Meta.parse("@foo @bar"),
-                Meta.parse("@foo(@bar)"),
-            ]
-            for expr in good_exprs
-                @test SciMLPublic._is_valid_macro_expr(expr)
-            end
-            for expr in bad_exprs
-                @test !SciMLPublic._is_valid_macro_expr(expr)
-            end
+        @safetestset "_is_valid_macro_expr" begin
+            include("macro_expr_tests.jl")
         end
-        @testset "_get_symbols" begin
-            @test SciMLPublic._get_symbols(:foo) == [:foo]
-            @test SciMLPublic._get_symbols(:((a, b, c))) == [:a, :b, :c]
-            @test SciMLPublic._get_symbols(:(@hello)) == [Symbol("@hello")]
-            @test SciMLPublic._get_symbols(:((foo, bar, @hello))) == [:foo, :bar, Symbol("@hello")]
+        @safetestset "_get_symbols" begin
+            include("get_symbols_tests.jl")
+        end
+
+        @safetestset "Tests for TestModule1" begin
+            include("testmodule1_tests.jl")
+        end
+
+        # Allocation tests - run in the Core/All groups
+        @safetestset "Allocation Tests" begin
+            include("alloc_tests.jl")
         end
     end
-
-    # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-
-    function _public_names(mod::Module)
-        result = Base.names(
-            mod;
-            all = false,
-            imported = false
-        )
-        return result
-    end
-
-    @testset "Tests for TestModule1" begin
-        @test Base.isexported(TestModule1, :f)
-        @test !Base.isexported(TestModule1, :g)
-        @test !Base.isexported(TestModule1, :h)
-
-        # `Base.ispublic` was added in Julia 1.11
-        @static if Base.VERSION >= v"1.11.0-DEV.469"
-            @test Base.ispublic(TestModule1, :f)
-            @test Base.ispublic(TestModule1, :g)
-            @test !Base.ispublic(TestModule1, :h)
-        end
-
-        @static if Base.VERSION >= v"1.11.0-DEV.469"
-            @test :f ∈ _public_names(TestModule1)
-            @test :g ∈ _public_names(TestModule1)
-            @test :h ∉ _public_names(TestModule1)
-        else
-            @test :f ∈ _public_names(TestModule1)
-            @test :g ∉ _public_names(TestModule1)
-            @test :h ∉ _public_names(TestModule1)
-        end
-    end
-
-    # Allocation tests - run in the Core/All groups
-    include("alloc_tests.jl")
 end

--- a/test/testmodule1_tests.jl
+++ b/test/testmodule1_tests.jl
@@ -1,0 +1,47 @@
+using SciMLPublic
+using Test
+
+module TestModule1
+
+    using SciMLPublic: @public
+
+    export f
+    @public g
+
+    function f end
+    function g end
+    function h end
+
+end # module TestModule1
+
+function _public_names(mod::Module)
+    result = Base.names(
+        mod;
+        all = false,
+        imported = false
+    )
+    return result
+end
+
+@testset "Tests for TestModule1" begin
+    @test Base.isexported(TestModule1, :f)
+    @test !Base.isexported(TestModule1, :g)
+    @test !Base.isexported(TestModule1, :h)
+
+    # `Base.ispublic` was added in Julia 1.11
+    @static if Base.VERSION >= v"1.11.0-DEV.469"
+        @test Base.ispublic(TestModule1, :f)
+        @test Base.ispublic(TestModule1, :g)
+        @test !Base.ispublic(TestModule1, :h)
+    end
+
+    @static if Base.VERSION >= v"1.11.0-DEV.469"
+        @test :f ∈ _public_names(TestModule1)
+        @test :g ∈ _public_names(TestModule1)
+        @test :h ∉ _public_names(TestModule1)
+    else
+        @test :f ∈ _public_names(TestModule1)
+        @test :g ∉ _public_names(TestModule1)
+        @test :h ∉ _public_names(TestModule1)
+    end
+end


### PR DESCRIPTION
## What

Converts the plain-`@testset` independent test units to `@safetestset` so each runs in its own freshly-generated module. This gives world-age safety and isolation between units, matching the canonical OrdinaryDiffEq test structure.

## Changes

- **`test/runtests.jl`**: the three independent units (`_is_valid_macro_expr`, `_get_symbols`, `Tests for TestModule1`) plus the allocation tests are now `@safetestset "X" begin include("x.jl") end`, kept inside the outer `@testset "SciMLPublic.jl package"` grouping (preserves the verbose summary grouping). The `GROUP=="QA"` vs else dispatch is unchanged.
- **New self-contained files** `test/macro_expr_tests.jl`, `test/get_symbols_tests.jl`, `test/testmodule1_tests.jl` — each carries its own `using SciMLPublic; using Test`. `TestModule1` and the `_public_names` helper moved into the extracted file so the `@public` package macro resolves after `using SciMLPublic` runs (a `@safetestset` body macroexpands as one unit, but `include()` evaluates statements sequentially, so the macro is defined before its use).
- **`test/qa/qa.jl`**: the `Aqua` and `JET` units are now `@safetestset`, each with its own imports. The `@test_broken` (tracking #34) is preserved verbatim.
- **Deps**: `SafeTestsets` added to the main `Project.toml` (`[extras]`/`[targets].test`/`[compat] = "0.1, 1"`) and to `test/qa/Project.toml` (`[deps]`/`[compat]`).

## Behavior preservation

Same GROUP dispatch, same tests, same assertions, same counts. Nested grouping `@testset`s inside `alloc_tests.jl` stay plain (the unit-level `@safetestset` already isolates).

## Verification (local, Julia 1.11)

- `GROUP=Core`: `SciMLPublic.jl package` 25/25 pass.
- `GROUP=QA`: `Aqua` 7 pass + 1 broken (the preserved `@test_broken`), `JET` 1 pass.

---

This is part of the @safetestset canonicalization campaign. Ignore until reviewed by @ChrisRackauckas.