### PR TITLE
export @public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLPublic"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 authors = ["The Julia Project", "contributors"]
-version = "1.1.0"
+version = "1.2.0"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"

--- a/src/SciMLPublic.jl
+++ b/src/SciMLPublic.jl
@@ -187,6 +187,11 @@ end
 # Shorter alias used internally
 const _valid_macro = _is_valid_macro_expr
 
-@public @public
+# `@public` is this package's entire API (documented), so export it. `export`
+# marks a name as public on all Julia versions (including the pre-1.11 LTS, where
+# native `public` marking is a no-op) and makes it usable via `using SciMLPublic`.
+# (We export rather than `@public @public` because on 1.11+ a name cannot be both
+# exported and `public`-declared.)
+export @public
 
 end # module Public


### PR DESCRIPTION
Export the `@public` macro — it is SciMLPublic's entire, documented API. It was only marked public via `@public @public`, which takes effect on Julia 1.11+ only; on the pre-1.11 LTS the native marking is a no-op, so `@public` reads as non-public there (e.g. SciMLBase #1397 must ignore-list it on <1.11). `export` makes a name public on **all** Julia versions and usable via `using SciMLPublic`. (Exporting rather than keeping `@public @public` because on 1.11+ a name cannot be both exported and `public`-declared.) Verified: exported + ispublic on 1.12 and 1.10, tests pass. version 1.1.0→1.2.0. Ignore until reviewed by @ChrisRackauckas.