### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "1.2.0"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1.10"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SciMLPublic = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,15 +1,4 @@
-using SciMLPublic
-using Aqua
+using SciMLTesting, SciMLPublic, Test
 using JET
-using Test
 
-@testset "Aqua" begin
-    # deps_compat(extras) currently fails; run the rest and mark it broken.
-    # Tracked in https://github.com/SciML/SciMLPublic.jl/issues/34
-    Aqua.test_all(SciMLPublic; deps_compat = false)
-    @test_broken false  # Aqua deps_compat: no [compat] for Aqua/JET extras — tracked in https://github.com/SciML/SciMLPublic.jl/issues/34
-end
-
-@testset "JET" begin
-    JET.test_package(SciMLPublic; target_defined_modules = true)
-end
+run_qa(SciMLPublic; explicit_imports = true)


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts `test/qa/qa.jl` from the hand-rolled `Aqua.test_all` + `JET.test_package` form onto the SciMLTesting 1.6.0 `run_qa` form, with the ExplicitImports check suite enabled.

## qa.jl

```julia
using SciMLTesting, SciMLPublic, Test
using JET

run_qa(SciMLPublic; explicit_imports = true)
```

## ExplicitImports findings

All six checks pass with **zero findings**, so no `ei_kwargs` ignore-lists and no `ei_broken` markers are needed:

- `no_implicit_imports` — pass
- `no_stale_explicit_imports` — pass
- `all_explicit_imports_via_owners` — pass
- `all_qualified_accesses_via_owners` — pass
- `all_qualified_accesses_are_public` — pass
- `all_explicit_imports_are_public` — pass

This is expected: SciMLPublic has no external dependencies (pure `Base` + `export @public`).

## Aqua / JET

Both pass with no broken markers.

## Dropped `@test_broken` (issue #34)

The old `qa.jl` carried a `@test_broken false` for Aqua `deps_compat` (issue #34: the main `Project.toml` `[extras]` declared `Aqua`/`JET` with no `[compat]`). That finding is **already resolved**: the folder-model conversion (#33/#35) moved `Aqua`/`JET` into `test/qa/Project.toml`, leaving the main `[extras]` with only `SafeTestsets`/`SciMLTesting`/`Test`, all of which have `[compat]` bounds. `Aqua.test_deps_compat(SciMLPublic)` now passes 4/4 locally, so the broken marker is genuinely no longer needed (not silenced). **Issue #34 can be closed.**

## Deps

- `SciMLTesting` compat bumped to `"1.6"` in both `Project.toml` and `test/qa/Project.toml`.
- `Aqua` kept (Aqua.test_ambiguities child-proc needs Aqua a direct dep).
- `JET` kept (JET runs).
- ExplicitImports is **not** a direct dep (transitive via SciMLTesting) — correct.

## Verification (vs released SciMLTesting 1.6.0, no dev-from-branch)

`GROUP=QA` `Pkg.test`:
- lts (1.10): `QA/qa.jl | 18 Pass | 18 Total` — 0 Fail/Error/Broken
- Julia 1 (1.12): `QA/qa.jl | 18 Pass | 18 Total` — 0 Fail/Error/Broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)