### PR TITLE
Update SciMLTesting QA docs checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "1.2.1"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1.10"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -13,6 +13,6 @@ SciMLPublic = {path = "../.."}
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "1.6"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Update root and QA SciMLTesting compat to 2.1.
- Use SciMLTesting's shared public API docs QA path; rendered docs checks are enabled where package docs exist.
- Add or render missing public API docstrings/docs entries where needed and remove stale repo-local public-docs QA where present.

## Local Validation
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.10 TOML parse over root/test/docs TOML files.
- PASS: no absolute QA [sources] paths and no test/Project.toml in this repo.
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.12 -m Runic --check <changed .jl files>.
- PASS: GROUP=QA timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e "using Pkg; Pkg.test()".
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e "using Pkg; Pkg.test()".

