### PR TITLE
Release prep: bump SciMLPublic to 1.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLPublic"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 authors = ["The Julia Project", "contributors"]
-version = "1.2.1"
+version = "1.2.2"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"


### PR DESCRIPTION
Patch release bump (1.2.1 -> 1.2.2) covering the accumulated docstring/QA/test scaffolding changes since the last release (SciMLTesting compat bump to 2.1 for the QA test group).