### PR TITLE
Remove QA self-source entry

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -6,9 +6,6 @@ SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[sources]
-SciMLPublic = {path = "../.."}
-
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Remove the redundant `test/qa/Project.toml` `[sources]` entry for `SciMLPublic`.
- Keep the QA entrypoint on `run_qa(SciMLPublic; explicit_imports = true)`, relying on SciMLTesting's default public API docs check instead of local self-source project metadata.

## Validation
- `GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'`
- QA Project source scan: `PASS: no [sources] sections or path entries in QA Project.toml files`
- Runic: not run because no Julia files were changed.