### PR TITLE
Release prep: bump version to 1.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLPublic"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 authors = ["The Julia Project", "contributors"]
-version = "1.2.2"
+version = "1.2.3"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"


### PR DESCRIPTION
## Summary

Bumps `version` in Project.toml from 1.2.2 to 1.2.3.

The last registered release corresponds to commit 9d0f07a651 ("Bump SciMLPublic to 1.2.2 for release (#43)"). Since then, one commit has landed on `main` without a version bump:

- #44 "Remove QA self-source entry" — removes a `[sources]` self-path override (`SciMLPublic = {path = "../.."}`) from `test/qa/Project.toml`.

## Bump type: PATCH (1.2.2 -> 1.2.3)

The only change since the last release is to a test-support Project.toml (`test/qa/Project.toml`), removing a dev-only source override used for local/CI testing. It does not touch any package source file, does not add or change any public API, and does not touch `[compat]` bounds on any dependency. This is a CI/test-config-only change, so a PATCH bump is appropriate.

## Compat bounds

Not touched. The diff since the last release does not add, remove, or change usage of any dependency (SciML-ecosystem or otherwise), so no compat lower-bound adjustments are needed.