### PR TITLE
Add SciMLPublic rendered API docs QA

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
+
+[compat]
+Documenter = "1"
+SciMLPublic = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,13 @@
+using Documenter
+using SciMLPublic
+
+makedocs(;
+    modules = [SciMLPublic],
+    sitename = "SciMLPublic.jl",
+    pages = [
+        "Home" => "index.md",
+    ],
+    checkdocs = :exports,
+)
+
+deploydocs(; repo = "github.com/SciML/SciMLPublic.jl")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,16 @@
+```@meta
+CurrentModule = SciMLPublic
+```
+
+# SciMLPublic.jl
+
+SciMLPublic provides the `@public` compatibility macro for packages that need to
+declare public API while still supporting Julia versions before the `public`
+keyword is available.
+
+## API
+
+```@docs
+SciMLPublic
+@public
+```

--- a/src/SciMLPublic.jl
+++ b/src/SciMLPublic.jl
@@ -72,7 +72,7 @@ using SciMLPublic: @public
 - Julia 1.11+: Uses native `public` keyword functionality
 - Julia <1.11: No-op for compatibility (symbols remain unexported but package will work)
 
-See also: [`export`](@ref)
+See also: `export`.
 """
 @static if Base.VERSION >= v"1.11.0-DEV.469"
     macro public(symbols_expr::Union{Symbol, Expr})

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,4 @@
 using SciMLTesting, SciMLPublic, Test
 using JET
 
-run_qa(SciMLPublic; explicit_imports = true)
+run_qa(SciMLPublic; api_docs_kwargs = (; rendered = true), explicit_imports = true)


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Add a minimal Documenter docs tree for SciMLPublic's package-owned public API.
- Render `SciMLPublic` and `@public` in the docs API page.
- Enable SciMLTesting rendered public API docs QA.
- Replace the `[`export`](@ref)` cross-reference in the `@public` docstring with plain code text so strict Documenter cross-reference checks pass.

## Validation
- `git diff --check` passed.
- QA passed with `api_docs_kwargs = (; rendered = true)`: Quality Assurance 18/18.
- `include("docs/make.jl")` passed; Documenter only emitted the expected local deployment skip warning.
- `Pkg.test()` passed: alloc 3/3, get_symbols 4/4, macro_expr 9/9, testmodule1 6/6.
- Runic v1.7.0 passed over `src`, `test`, and `docs`.

The new `docs/Project.toml` has no `[sources]` path entries.
