### PR TITLE
Bump SciMLPublic to v1.2.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SciMLPublic"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 authors = ["The Julia Project", "contributors"]
-version = "1.2.3"
+version = "1.2.4"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"


### PR DESCRIPTION
Bumps `SciMLPublic` **v1.2.3 → v1.2.4** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Add SciMLPublic rendered API docs QA (#46) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)