### PR TITLE
Require strict SciMLTesting 2.4 QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "1.2.4"
 
 [compat]
 SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "2.1"
+SciMLTesting = "2.4"
 Test = "1.10"
 julia = "1.10"
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,15 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLPublic = "431bcebd-1456-4ced-9d72-93c2757fff0b"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.0.1, 0.1, 1"
-SciMLTesting = "2.1"
-Test = "1"
+SciMLTesting = "2.4"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,4 +1,3 @@
-using SciMLTesting, SciMLPublic, Test
-using JET
+using SciMLTesting, SciMLPublic
 
-run_qa(SciMLPublic; api_docs_kwargs = (; rendered = true), explicit_imports = true)
+run_qa(SciMLPublic)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Updates the QA environment to SciMLTesting 2.4 and runs the default strict QA entrypoint without package-level exceptions or overrides.

Validation:
- Pkg.test() on Julia 1.10 and 1.12
- strict run_qa(SciMLPublic) on Julia 1.12: 20/20
- docs build with doctests
- Runic check